### PR TITLE
Coerce limit and skip to integers

### DIFF
--- a/lib/collectionFactory.ts
+++ b/lib/collectionFactory.ts
@@ -184,8 +184,8 @@ export abstract class CollectionFactory<TDocument extends IDocument> {
   ): Promise<TDocument[]> {
     return await this.collection()
       .find(query, fields)
-      .skip(skip ? skip : 0)
-      .limit(limit ? limit : Number.MAX_SAFE_INTEGER)
+      .skip(skip ? parseInt(skip as any) : 0)
+      .limit(limit ? parseInt(limit as any): Number.MAX_SAFE_INTEGER)
       .map(document => this.hydrateObject(document) || this.undefinedObject)
       .toArray()
   }
@@ -260,11 +260,11 @@ export abstract class CollectionFactory<TDocument extends IDocument> {
       }
 
       if (parameters.skip) {
-        cursor = cursor.skip(parameters.skip)
+        cursor = cursor.skip(parseInt(parameters.skip as any))
       }
 
       if (parameters.limit) {
-        cursor = cursor.limit(parameters.limit)
+        cursor = cursor.limit(parseInt(parameters.limit as any))
       }
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "document-ts",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "document-ts",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "A very thin TypeScript-based async MongoDB helper with optional ODM convenience features",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/documentSpec.ts
+++ b/tests/documentSpec.ts
@@ -87,6 +87,33 @@ describe('Document', function() {
     expect(expectedException).toEqual(actualException)
   })
 
+  it('should find with pagination given string skip and limit', async () => {
+    const expectedException = null
+    let actualException = null
+    const expectedRecordCount = 20
+
+    try {
+      for (let i = 0; i < expectedRecordCount; i++) {
+        let user = new User()
+        await user.create(`${i}`, `${i}`, `${i}@gmail.com`, 'user')
+      }
+    } catch (ex) {
+      actualException = ex
+    }
+
+    expect(expectedException).toEqual(actualException)
+
+    const dynamicInput: any = '10'
+
+    const results = await UserCollection.findWithPagination<User>({
+      skip: dynamicInput,
+      limit: dynamicInput,
+    })
+    expect(expectedRecordCount).toBe(results.total)
+    expect(results.data.length).toBe(10)
+    expect(results.data[0].firstName).toBe('10')
+  })
+
   it('should find with pagination', async () => {
     const expectedException = null
     let actualException = null


### PR DESCRIPTION
Addresses a convenience issue working with Swagger UI, where the tool submits integers as strings dynamically, bypassing typechecks. 

This changes calls `parseInt` any time limit and skip is used.

Added unit test.